### PR TITLE
Dependencies, tests, https and OpenCage Geocoder support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-/*global JSON,Buffer,require,exports*/
+/*global JSON,require,exports*/
 'use strict';
-var http = require('http'),
+var request = require('request'),
     url = require('url'),
     querystring = require('querystring');
 exports.location = function (config, callback) {
@@ -23,26 +23,23 @@ exports.location = function (config, callback) {
         break;
     }
     delete config.map;
-    //build interface address
     address += '&' + querystring.stringify(config);
-    var options = config.options || url.parse(address);
-    options.path = options.path || address;
+
     try {
-        http.get(options, function (response) {
-            var bufferList = [];
-            response.on('data', function (chunk) {
-                bufferList.push(chunk);
-            }).on('end', function () {
-                var data = JSON.parse(Buffer.concat(bufferList).toString());
-                //be ware, every interface return back data was not same.
-                if (data.status === 'OK' || data.status === 0) {
-                    callback(undefined, data);
-                } else {
-                    callback(data.status);
-                }
-            }).on('error', function (error) {
-                callback(error);
-            });
+        request(address, function (error, response, body) {
+            if (error) {
+              callback(error);
+              return;
+            }
+
+            var data = JSON.parse(body);
+
+            //be ware, every interface return back data was not same.
+            if (data.status === 'OK' || data.status === 0) {
+                callback(undefined, data);
+            } else {
+                callback(data.status);
+            }
         });
     }catch(err){
         callback(err);

--- a/index.js
+++ b/index.js
@@ -19,6 +19,9 @@ exports.location = function (config, callback) {
     case 'baidu':
         address = 'http://api.map.baidu.com/geocoder/v2/?output=json&location=' + latitude + ',' + longitude;
         break;
+    case 'opencage':
+        address = 'https://api.opencagedata.com/geocode/v1/json?q=' + latitude + ',' + longitude;
+        break;
     default:
         break;
     }
@@ -35,7 +38,7 @@ exports.location = function (config, callback) {
             var data = JSON.parse(body);
 
             //be ware, every interface return back data was not same.
-            if (data.status === 'OK' || data.status === 0) {
+            if (data.status === 'OK' || data.status === 0 || data.status.message === 'OK') {
                 callback(undefined, data);
             } else {
                 callback(data.status);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Reverse Geocoding for a Latitude and Longitude by Async.",
   "main": "main.js",
   "scripts": {
-    "test": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha -report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
+    "test": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha -report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
+    "lint": "node_modules/.bin/eslint ."
   },
   "keywords": [
     "geocoding",
@@ -24,6 +25,7 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "^4.1.2",
+    "eslint": "^4.11.0",
     "istanbul": "^0.4.5",
     "mocha": "^4.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "^4.1.2",
+    "istanbul": "^0.4.5",
     "mocha": "^4.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "^4.1.2",
+    "coveralls": "^3.0.0",
     "eslint": "^4.11.0",
     "istanbul": "^0.4.5",
     "mocha": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -21,5 +21,9 @@
     "email": "project@hostname.com"
   },
   "author": "s@zhso.net",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "chai": "^4.1.2",
+    "mocha": "^4.0.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
     "chai": "^4.1.2",
     "istanbul": "^0.4.5",
     "mocha": "^4.0.1"
+  },
+  "dependencies": {
+    "request": "^2.83.0"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,6 +11,10 @@ if(process.env['BAIDU_KEY']) {
   maps['baidu'] = { 'ak': process.env['BAIDU_KEY'] };
 }
 
+if(process.env['OPENCAGE_KEY']) {
+  maps['opencage'] = { 'key': process.env['OPENCAGE_KEY'] };
+}
+
 Object.keys(maps).forEach(function (map) {
     var options = maps[map];
     options['map'] = map;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -15,6 +15,18 @@ if(process.env['OPENCAGE_KEY']) {
   maps['opencage'] = { 'key': process.env['OPENCAGE_KEY'] };
 }
 
+var responseCheck = function(done) {
+    return function (err, data) {
+        if (err) {
+            done(new Error(err));
+        } else if (!data) {
+            done(new Error('No Data'));
+        } else {
+          done();
+        }
+    }
+};
+
 Object.keys(maps).forEach(function (map) {
     var options = maps[map];
     options['map'] = map;
@@ -33,30 +45,14 @@ Object.keys(maps).forEach(function (map) {
                 reverse.location(Object.assign({}, options, {
                     'latitude': 40.00403611111111,
                     'longitude': 116.48485555555555
-                }), function (err, data) {
-                    if (err) {
-                        done(new Error(err));
-                    } else if (!data) {
-                        done(new Error('No Data'));
-                    } else {
-                      done();
-                    }
-                });
+                }), responseCheck(done));
             });
             it('custom options should be valid.', function (done) {
                 reverse.location(Object.assign({}, options, {
                     'latitude': 40.00403611111111,
                     'longitude': 116.48485555555555,
                     'language': 'zh-cn'
-                }), function (err, data) {
-                    if (err) {
-                        done(new Error(err));
-                    } else if (!data) {
-                        done(new Error('No Data'));
-                    } else {
-                      done();
-                    }
-                });
+                }), responseCheck(done));
             });
         });
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -30,7 +30,13 @@ Object.keys(maps).forEach(function (map) {
                     'latitude': 40.00403611111111,
                     'longitude': 116.48485555555555
                 }), function (err, data) {
-                    data && done(); //
+                    if (err) {
+                        done(new Error(err));
+                    } else if (!data) {
+                        done(new Error('No Data'));
+                    } else {
+                      done();
+                    }
                 });
             });
             it('custom options should be valid.', function (done) {
@@ -39,7 +45,13 @@ Object.keys(maps).forEach(function (map) {
                     'longitude': 116.48485555555555,
                     'language': 'zh-cn'
                 }), function (err, data) {
-                    data && done();
+                    if (err) {
+                        done(new Error(err));
+                    } else if (!data) {
+                        done(new Error('No Data'));
+                    } else {
+                      done();
+                    }
                 });
             });
         });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,31 +2,46 @@
 var reverse = require('./../index.js'),
     chai = require('chai'),
     expect = chai.expect;
-describe(".location()", function () {
-    it("{arguments} number invalid should throw error.", function () {
-        expect(reverse.location).to.throw(Error);
-    });
-    it('{latitude} or {longitude} undefined should throw error.', function () {
-        expect(function () {
-            reverse.location({}, function () {});
-        }).to.throw(Error);
-    });
-    it('valid gps should return location.', function (done) {
-        reverse.location({
-            'latitude': 40.00403611111111,
-            'longitude': 116.48485555555555
-        }, function (err, data) {
-            data && done(); //
+
+var maps = {
+  'google': {}
+};
+
+if(process.env['BAIDU_KEY']) {
+  maps['baidu'] = { 'ak': process.env['BAIDU_KEY'] };
+}
+
+Object.keys(maps).forEach(function (map) {
+    var options = maps[map];
+    options['map'] = map;
+
+    describe(map, function() {
+        describe(".location()", function () {
+            it("{arguments} number invalid should throw error.", function () {
+                expect(reverse.location).to.throw(Error);
+            });
+            it('{latitude} or {longitude} undefined should throw error.', function () {
+                expect(function () {
+                    reverse.location(options, function () {});
+                }).to.throw(Error);
+            });
+            it('valid gps should return location.', function (done) {
+                reverse.location(Object.assign({}, options, {
+                    'latitude': 40.00403611111111,
+                    'longitude': 116.48485555555555
+                }), function (err, data) {
+                    data && done(); //
+                });
+            });
+            it('custom options should be valid.', function (done) {
+                reverse.location(Object.assign({}, options, {
+                    'latitude': 40.00403611111111,
+                    'longitude': 116.48485555555555,
+                    'language': 'zh-cn'
+                }), function (err, data) {
+                    data && done();
+                });
+            });
         });
     });
-    it('custom options should be valid.', function (done) {
-        reverse.location({
-            'latitude': 40.00403611111111,
-            'longitude': 116.48485555555555,
-            'language': 'zh-cn'
-        }, function (err, data) {
-            data && done();
-        });
-    });
-    //because baidu maps need private token, so... pass the test;)
 });


### PR DESCRIPTION
Hi there! :smile: 

This PR adds support for the [OpenCage Geocoder](https://geocoder.opencagedata.com/) to your reverse-geocoding project.

To get started on the project I had to install a few dependencies in order to be able to run the tests, so I've added those to your packages.json's `devDependencies` section.

I made it so that the test can get the keys for Baidu and OpenCage from the environment variables.

    $ BAIDU_KEY='abc' OPENCAGE_KEY='abc' npm test

I tested this with my own OpenCage key and it works well. I don't have a Baidu key to test with and I couldn't navigate the site in Chinese. If you have one can you check that it works?

Finally, for adding OpenCage Geocoder support I wanted to add HTTPS support. For that I thought it would be easiest if I switched from http to [request](https://github.com/request/request). This does mean adding a dependency. If you'd rather stick with the core http/https agent libraries and the manual buffer handling I understand and I can do that for you instead if you'd prefer.

I decided not to switch Google and Baidu over to HTTPS because I wasn't sure why you had chosen to do HTTP by default. It should just work if you change the protocol from http to https in your Google and Baidu URLs.

Let me know if you have any questions about any of the changes I've made. Thanks!

Alex