### PR TITLE
Added support for Google Maps API Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Basic
 var geocoding = new require('reverse-geocoding');
 var config = {
     'latitude': 40.00403611111111,
-    'longitude': 116.48485555555555
+    'longitude': 116.48485555555555,
+    'apiKey': ***Your Google Maps API Key***
 };
 geocoding(config, function (err, data){
 	if(err){

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,13 +19,14 @@ module.exports = function (config, callback) {
 
   var latitude = config.latitude,
       longitude = config.longitude,
+      apiKey = config.apiKey, //Added support to add google maps API key
       map = config.map;
 
 
   delete config.latitude; // eslint-disable-line no-param-reassign
   delete config.longitude; // eslint-disable-line no-param-reassign
 
-  var address = 'https://maps.googleapis.com/maps/api/geocode/json?latlng=' + latitude + ',' + longitude;
+  var address = 'https://maps.googleapis.com/maps/api/geocode/json?latlng=' + latitude + ',' + longitude + '&key=' + apiKey; //Added support to add google maps API key
 
   switch (map) {
     case 'baidu':


### PR DESCRIPTION
The present code does not work because the Google Maps URL now needs an API key to be included.
I've added the necessary lines of code to support API Keys and pass them through the configuration on the users' end. 